### PR TITLE
Update Django requirement to >=1.11.19

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-Django==1.7.1
+django>=1.11.19,<2.0
 
 azure==0.9.0
 django-redis-cache==0.13.0


### PR DESCRIPTION
1.11.19 contains a security fix, so that should now be the minimum.